### PR TITLE
Fix for logging to work on SDK environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Local SDK Support
 This package has been changed from shpasser's version for more compatibility for those working with the local GAE SDK.
 
-[![Latest Stable Version](https://poser.pugx.org/iamacarpet/gae-support-lumen/v/stable)](https://packagist.org/packages/iamacarpet/gae-support-lumen) [![Total Downloads](https://poser.pugx.org/iamacarpet/gae-support-lumen/downloads)](https://packagist.org/packages/iamacarpet/gae-support-lumen) [![Latest Unstable Version](https://poser.pugx.org/iamacarpet/gae-support-lumen/v/unstable)](https://packagist.org/packages/iamacarpet/gae-support-lumen) [![License](https://poser.pugx.org/iamacarpet/gae-support-lumen/license)](https://packagist.org/packages/iamacarpet/gae-support-lumen)
+[![Latest Stable Version](https://poser.pugx.org/a1comms/gae-support-lumen/v/stable)](https://packagist.org/packages/a1comms/gae-support-lumen) [![Total Downloads](https://poser.pugx.org/a1comms/gae-support-lumen/downloads)](https://packagist.org/packages/a1comms/gae-support-lumen) [![Latest Unstable Version](https://poser.pugx.org/a1comms/gae-support-lumen/v/unstable)](https://packagist.org/packages/a1comms/gae-support-lumen) [![License](https://poser.pugx.org/a1comms/gae-support-lumen/license)](https://packagist.org/packages/a1comms/gae-support-lumen)
 
 Google App Engine(GAE) Support package for Lumen.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Local SDK Support
 This package has been changed from shpasser's version for more compatibility for those working with the local GAE SDK.
 
-[![Latest Stable Version](https://poser.pugx.org/iamacarpet/gae-support-lumen/v/stable)](https://packagist.org/packages/shpasser/gae-support-lumen) [![Total Downloads](https://poser.pugx.org/iamacarpet/gae-support-lumen/downloads)](https://packagist.org/packages/shpasser/gae-support-lumen) [![Latest Unstable Version](https://poser.pugx.org/iamacarpet/gae-support-lumen/v/unstable)](https://packagist.org/packages/shpasser/gae-support-lumen) [![License](https://poser.pugx.org/iamacarpet/gae-support-lumen/license)](https://packagist.org/packages/shpasser/gae-support-lumen)
+[![Latest Stable Version](https://poser.pugx.org/iamacarpet/gae-support-lumen/v/stable)](https://packagist.org/packages/iamacarpet/gae-support-lumen) [![Total Downloads](https://poser.pugx.org/iamacarpet/gae-support-lumen/downloads)](https://packagist.org/packages/iamacarpet/gae-support-lumen) [![Latest Unstable Version](https://poser.pugx.org/iamacarpet/gae-support-lumen/v/unstable)](https://packagist.org/packages/iamacarpet/gae-support-lumen) [![License](https://poser.pugx.org/iamacarpet/gae-support-lumen/license)](https://packagist.org/packages/iamacarpet/gae-support-lumen)
 
 Google App Engine(GAE) Support package for Lumen.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # GaeSupport
 
-[![Latest Stable Version](https://poser.pugx.org/shpasser/gae-support-lumen/v/stable)](https://packagist.org/packages/shpasser/gae-support-lumen) [![Total Downloads](https://poser.pugx.org/shpasser/gae-support-lumen/downloads)](https://packagist.org/packages/shpasser/gae-support-lumen) [![Latest Unstable Version](https://poser.pugx.org/shpasser/gae-support-lumen/v/unstable)](https://packagist.org/packages/shpasser/gae-support-lumen) [![License](https://poser.pugx.org/shpasser/gae-support-lumen/license)](https://packagist.org/packages/shpasser/gae-support-lumen)
+## Local SDK Support
+This package has been changed from shpasser's version for more compatibility for those working with the local GAE SDK.
+
+[![Latest Stable Version](https://poser.pugx.org/iamacarpet/gae-support-lumen/v/stable)](https://packagist.org/packages/shpasser/gae-support-lumen) [![Total Downloads](https://poser.pugx.org/iamacarpet/gae-support-lumen/downloads)](https://packagist.org/packages/shpasser/gae-support-lumen) [![Latest Unstable Version](https://poser.pugx.org/iamacarpet/gae-support-lumen/v/unstable)](https://packagist.org/packages/shpasser/gae-support-lumen) [![License](https://poser.pugx.org/iamacarpet/gae-support-lumen/license)](https://packagist.org/packages/shpasser/gae-support-lumen)
 
 Google App Engine(GAE) Support package for Lumen.
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "shpasser/gae-support-lumen",
+    "name": "iamacarpet/gae-support-lumen",
     "description": "Google App Engine Support for Lumen apps.",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
     "name": "iamacarpet/gae-support-lumen",
-    "description": "Google App Engine Support for Lumen apps.",
+    "description": "Google App Engine & Local SDK Support for Lumen apps.",
     "license": "MIT",
     "authors": [
         {
             "name": "Ron Shpasser",
             "email": "shpasser@gmail.com"
+        },
+        {
+            "name": "Samuel Melrose",
+            "email": "sam@infitialis.com"
         }
     ],
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "iamacarpet/gae-support-lumen",
+    "name": "a1comms/gae-support-lumen",
     "description": "Google App Engine & Local SDK Support for Lumen apps.",
     "license": "MIT",
     "authors": [

--- a/src/Shpasser/GaeSupportLumen/Foundation/Application.php
+++ b/src/Shpasser/GaeSupportLumen/Foundation/Application.php
@@ -136,7 +136,7 @@ class Application extends LumenApplication {
 
         $AppIdentityService = self::GAE_ID_SERVICE;
         $this->appId = $AppIdentityService::getApplicationId();
-        $this->runningOnGae = ! preg_match('/dev~/', getenv('APPLICATION_ID'));
+        $this->runningOnGae = true;
     }
 
     /**


### PR DESCRIPTION
Hello,

Currently logging doesn't work in the local SDK, as it's still trying to write to the file system even though it is forced to be read-only.

I couldn't see why `$this->runningOnGae` couldn't be true for dev too, but please let me know if there is a reason.

Regards,
iamacarpet
